### PR TITLE
magento/magento2#35535: Magento 2.4.4 Mini cart item images not showing

### DIFF
--- a/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
@@ -538,8 +538,8 @@ class Gd2 extends AbstractAdapter
         } elseif ($this->getWatermarkPosition() == self::POSITION_STRETCH) {
             $watermark = $this->createWaterMark($watermark, $this->_imageSrcWidth, $this->_imageSrcHeight);
         } elseif ($this->getWatermarkPosition() == self::POSITION_CENTER) {
-            $positionX = $this->_imageSrcWidth / 2 - imagesx($watermark) / 2;
-            $positionY = $this->_imageSrcHeight / 2 - imagesy($watermark) / 2;
+            $positionX = (int) ($this->_imageSrcWidth / 2 - imagesx($watermark) / 2);
+            $positionY = (int) ($this->_imageSrcHeight / 2 - imagesy($watermark) / 2);
             $this->imagecopymergeWithAlphaFix(
                 $this->_imageHandler,
                 $watermark,

--- a/lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php
@@ -334,8 +334,8 @@ class ImageMagick extends AbstractAdapter
                 $watermark->sampleImage($this->_imageSrcWidth, $this->_imageSrcHeight);
                 break;
             case self::POSITION_CENTER:
-                $positionX = ($this->_imageSrcWidth - $watermark->getImageWidth()) / 2;
-                $positionY = ($this->_imageSrcHeight - $watermark->getImageHeight()) / 2;
+                $positionX = (int) (($this->_imageSrcWidth - $watermark->getImageWidth()) / 2);
+                $positionY = (int) (($this->_imageSrcHeight - $watermark->getImageHeight()) / 2);
                 break;
             case self::POSITION_TOP_RIGHT:
                 $positionX = $this->_imageSrcWidth - $watermark->getImageWidth();


### PR DESCRIPTION
- Cast resized image dimensions from floats to integers for GD and ImageMagick as imagecopy expects ints

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
If images have odd dimensions then when they are resized in the image adapters for GD and ImageMagick the resulting dimensions are stored as floats:

`$positionX = $this->_imageSrcWidth / 2 - imagesx($watermark) / 2;`

These are later passed to PHP's imagecopy function which expects integers and so throws warnings. This results in the offending image size being missed when generating catalog images. Simply casting the results of the resizing lines to ints fixes this.

`$positionX = (int) ($this->_imageSrcWidth / 2 - imagesx($watermark) / 2);`

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35535

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. As mentioned in the issue thread by @benyatesvortex, this can be tested by running the image resize command manually (bin/magento catalog:image:resize). If either the width or height are odd (and the watermark is even), the result will be a float causing imagecopy() to throw a warning and the image to be skipped.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
